### PR TITLE
Bring external.mk back for the font packages

### DIFF
--- a/external.mk
+++ b/external.mk
@@ -1,0 +1,2 @@
+# Include system-specific packages
+include $(sort $(wildcard $(NERVES_DEFCONFIG_DIR)/package/*/*.mk))


### PR DESCRIPTION
I believe that we forgot to add the `external.mk` back after it got removed along with the `qt-webengine-kiosk` package in ca5fd7a987e246ba849fb3ebd27d8bf1a45c8dc2. The packages to add noto fonts are not compiled. This should fix #35 .