### PR TITLE
Example app - Set kiosk homepage to KIOSK_URL env variabel

### DIFF
--- a/example/config/config.exs
+++ b/example/config/config.exs
@@ -47,7 +47,8 @@ config :webengine_kiosk,
   fullscreen: true,
   background_color: "black",
   progress: true,
-  sounds: false
+  sounds: false,
+  homepage: System.get_env("KIOSK_URL")
 
 # Authorize the device to receive firmware using your public key.
 # See https://hexdocs.pm/nerves_firmware_ssh/readme.html for more information


### PR DESCRIPTION
I might have missed something but while testing the example app I had to add this line to the config for the app to actually use the environment variable the readme says to set (KIOSK_URL).